### PR TITLE
handle filenames with spaces

### DIFF
--- a/src/git_scan/git_scan.py
+++ b/src/git_scan/git_scan.py
@@ -73,7 +73,7 @@ def scan_files(tree_hash: str, repo_path: pathlib.Path, sub_path: pathlib.Path) 
     # Recursively handle trees for subfolders.
     data_files = []
     for line in output.split("\n"):
-        _, otype, ohash, oname = line.split()
+        _, otype, ohash, oname = line.split(maxsplit=3)
 
         # Handle subtree.
         if otype == "tree":


### PR DESCRIPTION
Since we work on Windows, we have a whole bunch of filenames with spaces.

The old code yielded a bug here: 
```bash
# example problematic commit line
100644 blob f6ffa0169c27a67efbef45ff9da82ec8062531d0\tfilename - Copy.json
# code
_, otype, ohash, oname = line.split()
# yields
ValueError: too many values to unpack (expected 4)
# because the split yields [100644, blob, f6ff...filename, -, Copy.json]
```

New code imposes a maximum amount of splits, so that any spaces after the hash remain together in the final piece, the `oname`.

-Joren

